### PR TITLE
Convert driver to async

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,9 @@ async methods.  This allows the driver to play nice with other async code especi
 running operations such as reading and averaging dozens of samples.  The original driver blocks all code execution
 while waiting for data to become available while this one will yield (a zero async sleep) to allow other code to run.
 
+Since checking the availability of and reading data from the load cell is already non-blocking this is mostly useful for
+enabling non-blocking initialization, but also serves as a good example of how to read data in an async friendly way.
+
 
 Dependencies
 =============

--- a/README.rst
+++ b/README.rst
@@ -71,11 +71,12 @@ Usage Example
 
 .. code-block:: py
 
+    import asyncio
     import board
     from cedargrove_nau7802_async import NAU7802
 
     # Instantiate NAU7802 ADC
-    nau7802 = NAU7802(board.I2C(), address=0x2A, active_channels=2)
+    nau7802 = await NAU7802.create_async(board.I2C(), address=0x2A, active_channels=2)
 
 ``nau7802_simpletest.py`` and other examples can be found in the ``examples`` folder.
 

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,11 @@ Introduction
     :target: https://github.com/psf/black
     :alt: Code Style: Black
 
-A CircuitPython driver class for the NAU7802 24-bit ADC.
+A async CircuitPython driver class for the NAU7802 24-bit ADC.  This is a fork of the original
+`NAU7802 driver <https://github.com/CedarGroveStudios/CircuitPython_NAU7802>` that converts certain operations into
+async methods.  This allows the driver to play nice with other async code especially if you're doing potentially long
+running operations such as reading and averaging dozens of samples.  The original driver blocks all code execution
+while waiting for data to become available while this one will yield (a zero async sleep) to allow other code to run.
 
 
 Dependencies
@@ -28,6 +32,7 @@ This driver depends on:
 * `Adafruit CircuitPython <https://github.com/adafruit/circuitpython>`_
 * `Bus Device <https://github.com/adafruit/Adafruit_CircuitPython_BusDevice>`_
 * `Register <https://github.com/adafruit/Adafruit_CircuitPython_Register>`_
+* `Asyncio <https://github.com/adafruit/Adafruit_CircuitPython_asyncio>`_
 
 Please ensure all dependencies are available on the CircuitPython filesystem.
 This is easily achieved by downloading
@@ -50,7 +55,7 @@ following command to install:
 
 .. code-block:: shell
 
-    circup install cedargrove_nau7802
+    circup install cedargrove_nau7802_async
 
 Or the following command to update an existing version:
 
@@ -64,7 +69,7 @@ Usage Example
 .. code-block:: py
 
     import board
-    from cedargrove_nau7802 import NAU7802
+    from cedargrove_nau7802_async import NAU7802
 
     # Instantiate NAU7802 ADC
     nau7802 = NAU7802(board.I2C(), address=0x2A, active_channels=2)

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Introduction
     :alt: Code Style: Black
 
 An async CircuitPython driver class for the NAU7802 24-bit ADC.  This is a fork of the original
-`NAU7802 driver <https://github.com/adafruit/CircuitPython_NAU7802>` that converts certain operations into
+`NAU7802 driver <https://github.com/adafruit/CircuitPython_NAU7802>`_ that converts certain operations into
 async methods.  This allows the driver to play nice with other async code especially if you're doing potentially long
 running operations such as reading and averaging dozens of samples.  The original driver blocks all code execution
 while waiting for data to become available while this one will yield (a zero async sleep) to allow other code to run.

--- a/README.rst
+++ b/README.rst
@@ -18,8 +18,8 @@ Introduction
     :target: https://github.com/psf/black
     :alt: Code Style: Black
 
-A async CircuitPython driver class for the NAU7802 24-bit ADC.  This is a fork of the original
-`NAU7802 driver <https://github.com/CedarGroveStudios/CircuitPython_NAU7802>` that converts certain operations into
+An async CircuitPython driver class for the NAU7802 24-bit ADC.  This is a fork of the original
+`NAU7802 driver <https://github.com/adafruit/CircuitPython_NAU7802>` that converts certain operations into
 async methods.  This allows the driver to play nice with other async code especially if you're doing potentially long
 running operations such as reading and averaging dozens of samples.  The original driver blocks all code execution
 while waiting for data to become available while this one will yield (a zero async sleep) to allow other code to run.

--- a/cedargrove_nau7802_async.py
+++ b/cedargrove_nau7802_async.py
@@ -128,6 +128,8 @@ class NAU7802:
         self._adc_out = None  # Initialize for later use
 
     async def init_async(self):
+        """Initialize NAU7802 device.  The reset and enable methods both have long running waits in them so we want
+        to do them asynchronously."""
         if not await self.reset_async():
             raise RuntimeError("NAU7802 device could not be reset")
         if not await self.enable_async(True):

--- a/cedargrove_nau7802_async.py
+++ b/cedargrove_nau7802_async.py
@@ -128,8 +128,8 @@ class NAU7802:
         self._adc_out = None  # Initialize for later use
 
     async def init_async(self):
-        """Initialize NAU7802 device.  The reset and enable methods both have long running waits in them so we want
-        to do them asynchronously."""
+        """Initialize NAU7802 device.  The reset and enable methods both have long
+        running waits in them so we want to do them asynchronously."""
         if not await self.reset_async():
             raise RuntimeError("NAU7802 device could not be reset")
         if not await self.enable_async(True):

--- a/cedargrove_nau7802_async.py
+++ b/cedargrove_nau7802_async.py
@@ -107,15 +107,16 @@ class CalibrationMode:
 class NAU7802:
     """The primary NAU7802 class."""
 
-    # pylint: disable=too-many-instance-attributes
-    def __init__(self, i2c_bus, address=0x2A, active_channels=1):
+    @staticmethod
+    async def create_async(i2c_bus, address=0x2A, active_channels=1):
         """Instantiate NAU7802; LDO 3v0 volts, gain 128, 10 samples per second
         conversion rate, disabled ADC chopper clock, low ESR caps, and PGA output
         stabilizer cap if in single channel mode."""
+        self = NAU7802()
         self.i2c_device = I2CDevice(i2c_bus, address)
-        if not self.reset_async():
+        if not await self.reset_async():
             raise RuntimeError("NAU7802 device could not be reset")
-        if not self.enable(True):
+        if not await self.enable_async(True):
             raise RuntimeError("NAU7802 device could not be enabled")
         self.ldo_voltage = "3V0"  # 3.0-volt internal analog power (AVDD)
         self._pu_ldo_source = True  # Internal analog power (AVDD)
@@ -131,6 +132,8 @@ class NAU7802:
             self._pc_cap_enable = 0x0
         self._calib_mode = None  # Initialize for later use
         self._adc_out = None  # Initialize for later use
+
+        return self
 
     # DEFINE I2C DEVICE BITS, NYBBLES, BYTES, AND REGISTERS
     # Chip Revision  R-

--- a/cedargrove_nau7802_async.py
+++ b/cedargrove_nau7802_async.py
@@ -287,6 +287,27 @@ class NAU7802:
         self._adc_out = value / 128  # Restore to 24-bit signed integer value
         return self._adc_out
 
+    async def read_async(self, samples=2):
+        """Read and average consecutive raw sample values. Return average raw value."""
+        sample_sum = 0
+        sample_count = samples
+        while sample_count > 0:
+            while not self.available():
+                await asyncio.sleep(0)
+            sample_sum = sample_sum + self.read()
+            sample_count -= 1
+        return int(sample_sum / samples)
+
+    async def read_values_async(self, samples=2):
+        """Read consecutive raw sample values. Return the set of raw value."""
+        samples = []
+        sample_count = samples
+        while sample_count > 0:
+            while not self.available():
+                await asyncio.sleep(0)
+            samples.append(self.read())
+        return samples
+
     async def reset_async(self):
         """Resets all device registers and enables digital system power.
         Returns the power ready status bit value: True when system is ready;

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,5 +1,5 @@
 
 .. If you created a package, create one automodule per module in the package.
 
-.. automodule:: cedargrove_nau7802
+.. automodule:: cedargrove_nau7802_async
    :members:

--- a/examples/nau7802_simpletest.py
+++ b/examples/nau7802_simpletest.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 """
-nau7802_simpletest.py  2023-01-13 2.0.2  Cedar Grove Maker Studios
+nau7802_async_simpletest.py  2023-01-13 2.0.2  Cedar Grove Maker Studios
 
 Instantiates two NAU7802 channels with default gain of 128 and sample
 average count of 2.
@@ -10,62 +10,66 @@ average count of 2.
 
 import time
 import board
-from cedargrove_nau7802 import NAU7802
+import asyncio
+from cedargrove_nau7802_async import NAU7802
 
 # Instantiate 24-bit load sensor ADC; two channels, default gain of 128
 nau7802 = NAU7802(board.I2C(), address=0x2A, active_channels=2)
 
 
-def zero_channel():
+def zero_channel(channel: int = 1):
     """Initiate internal calibration for current channel.Use when scale is started,
     a new channel is selected, or to adjust for measurement drift. Remove weight
     and tare from load cell before executing."""
+    nau7802.channel = channel
+
     print(
         "channel %1d calibrate.INTERNAL: %5s"
-        % (nau7802.channel, nau7802.calibrate("INTERNAL"))
+        % (nau7802.channel, nau7802.calibrate_async("INTERNAL"))
     )
     print(
         "channel %1d calibrate.OFFSET:   %5s"
-        % (nau7802.channel, nau7802.calibrate("OFFSET"))
+        % (nau7802.channel, nau7802.calibrate_async("OFFSET"))
     )
     print("...channel %1d zeroed" % nau7802.channel)
 
 
-def read_raw_value(samples=2):
+async def read_raw_value(channel: int = 1, samples=2):
     """Read and average consecutive raw sample values. Return average raw value."""
     sample_sum = 0
     sample_count = samples
     while sample_count > 0:
         while not nau7802.available():
+            await asyncio.sleep(0)  # Let us play nice with anything else async
             pass
         sample_sum = sample_sum + nau7802.read()
         sample_count -= 1
     return int(sample_sum / samples)
 
 
-# Instantiate and calibrate load cell inputs
-print("*** Instantiate and calibrate load cells")
-# Enable NAU7802 digital and analog power
-enabled = nau7802.enable(True)
-print("Digital and analog power enabled:", enabled)
+async def simple_test():
+    # Instantiate and calibrate load cell inputs
+    print("*** Instantiate and calibrate load cells")
+    # Enable NAU7802 digital and analog power
+    enabled = await nau7802.enable_async(True)
+    print("Digital and analog power enabled:", enabled)
 
-print("REMOVE WEIGHTS FROM LOAD CELLS")
-time.sleep(3)
+    print("REMOVE WEIGHTS FROM LOAD CELLS")
+    time.sleep(3)
 
-nau7802.channel = 1
-zero_channel()  # Calibrate and zero channel
-nau7802.channel = 2
-zero_channel()  # Calibrate and zero channel
+    await zero_channel(1)  # Calibrate and zero channel
+    await zero_channel(2)  # Calibrate and zero channel
 
-print("READY")
+    print("READY")
 
-### Main loop: Read load cells and display raw values
-while True:
-    print("=====")
-    nau7802.channel = 1
-    value = read_raw_value()
-    print("channel %1.0f raw value: %7.0f" % (nau7802.channel, value))
+    ### Main loop: Read load cells and display raw values
+    while True:
+        print("=====")
+        value = await read_raw_value(1)
+        print("channel %1.0f raw value: %7.0f" % (nau7802.channel, value))
 
-    nau7802.channel = 2
-    value = read_raw_value()
-    print("channel %1.0f raw value: %7.0f" % (nau7802.channel, value))
+        value = await read_raw_value(2)
+        print("channel %1.0f raw value: %7.0f" % (nau7802.channel, value))
+
+
+asyncio.run(simple_test())

--- a/examples/nau7802_simpletest.py
+++ b/examples/nau7802_simpletest.py
@@ -14,14 +14,15 @@ import board
 import asyncio
 from cedargrove_nau7802_async import NAU7802
 
-# Instantiate 24-bit load sensor ADC; two channels, default gain of 128
-nau7802 = NAU7802(board.I2C(), address=0x2A, active_channels=2)
+
+nau7802 = None
 
 
 def zero_channel(channel: int = 1):
     """Initiate internal calibration for current channel.Use when scale is started,
     a new channel is selected, or to adjust for measurement drift. Remove weight
     and tare from load cell before executing."""
+    global nau7802
     nau7802.channel = channel
 
     print(
@@ -38,11 +39,15 @@ def zero_channel(channel: int = 1):
 async def read_raw_value(channel: int):
     """Read an averaged value from average a given channel.  Use a larger number
     of samples to show how it interacts with other async methods.."""
+    global nau7802
     nau7802.channel = channel
     return await nau7802.read_async(samples=10)
 
 
 async def simple_test():
+    global nau7802
+    nau7802 = await NAU7802.create_async(board.I2C(), address=0x2A, active_channels=2)
+
     # Instantiate and calibrate load cell inputs
     print("*** Instantiate and calibrate load cells")
     # Enable NAU7802 digital and analog power

--- a/examples/nau7802_simpletest.py
+++ b/examples/nau7802_simpletest.py
@@ -10,12 +10,12 @@ average count of 2.
 
 import time
 import datetime
-import board
 import asyncio
+import board
 from cedargrove_nau7802_async import NAU7802
 
 
-nau7802 = None
+nau7802: NAU7802 = None
 
 
 def zero_channel(channel: int = 1):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,13 +11,14 @@ requires = [
 
 [project]
 name = "cedargrove-nau7802"
-description = "A CircuitPython driver class for the NAU7802 24-bit ADC"
+description = "A async CircuitPython driver class for the NAU7802 24-bit ADC"
 version = "0.0.0+auto.0"
 readme = "README.rst"
 authors = [
-    {name = "Adafruit Industries", email = "circuitpython@adafruit.com"}
+    {name = "Adafruit Industries", email = "circuitpython@adafruit.com"},
+    {name = "Ben Randall", email = "veleek@gmail.com"}
 ]
-urls = {Homepage = "https://github.com/adafruit/CircuitPython_NAU7802"}
+urls = {Homepage = "https://github.com/veleek/CircuitPython_NAU7802_Async"}
 keywords = [
     "adafruit",
     "nau7802",
@@ -26,6 +27,7 @@ keywords = [
     "hardware",
     "micropython",
     "circuitpython",
+    "asyncio",
 ]
 license = {text = "MIT"}
 classifiers = [
@@ -39,7 +41,7 @@ classifiers = [
 dynamic = ["dependencies", "optional-dependencies"]
 
 [tool.setuptools]
-py-modules = ["cedargrove_nau7802"]
+py-modules = ["cedargrove_nau7802_async"]
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@
 Adafruit-Blinka
 adafruit-circuitpython-busdevice
 adafruit-circuitpython-register
+asyncio


### PR DESCRIPTION
A number of methods on the original driver block code (either with explicit sleeps or spin locks). This converts those methods to be async to enable the driver to play nice with other async code.